### PR TITLE
Replace tone() with new ISR-based tone generator

### DIFF
--- a/arduino/scout/Frequency.cpp
+++ b/arduino/scout/Frequency.cpp
@@ -9,7 +9,7 @@ Frequency::Frequency(float glide, int cyclesPerGlideMax) {
 
 float Frequency::get() { return _frequency; }
 
-uint8_t Frequency::getTicks() { return _ticks; }
+uint16_t Frequency::getTicks() { return _ticks; }
 
 void Frequency::update(float target, float glide) {
   _target = target;
@@ -28,7 +28,7 @@ void Frequency::update(float target, float glide) {
                        ? min(_target, _frequency + _glideStep)
                        : max(_target, _frequency - _glideStep);
     }
-    _ticks = (uint8_t)((31250.0f / _frequency) + 0.5f);
+    _ticks = (uint16_t)((31250.0f / _frequency) + 0.5f);
   }
 
   if (!needsUpdate) {

--- a/arduino/scout/Frequency.cpp
+++ b/arduino/scout/Frequency.cpp
@@ -9,6 +9,8 @@ Frequency::Frequency(float glide, int cyclesPerGlideMax) {
 
 float Frequency::get() { return _frequency; }
 
+uint8_t Frequency::getTicks() { return _ticks; }
+
 void Frequency::update(float target, float glide) {
   _target = target;
   bool needsUpdate = _frequency != _target;
@@ -26,6 +28,7 @@ void Frequency::update(float target, float glide) {
                        ? min(_target, _frequency + _glideStep)
                        : max(_target, _frequency - _glideStep);
     }
+    _ticks = (uint8_t)((31250.0f / _frequency) + 0.5f);
   }
 
   if (!needsUpdate) {
@@ -33,10 +36,11 @@ void Frequency::update(float target, float glide) {
   }
 }
 
-void Frequency::reset() { _frequency = 0; }
+void Frequency::reset() { _frequency = 0; _ticks = 0; }
 
 void Frequency::print() {
   Serial.println("frequency:" + String(_frequency) +
+                 ",ticks:" + String(_ticks) +
                  ",target:" + String(_target) +
                  ",previousTargetFrequency:" + String(_previousTarget));
 }

--- a/arduino/scout/Frequency.cpp
+++ b/arduino/scout/Frequency.cpp
@@ -11,6 +11,8 @@ float Frequency::get() { return _frequency; }
 
 uint16_t Frequency::getTicks() { return _ticks; }
 
+uint16_t Frequency::getPeriod() { return _period; }
+
 void Frequency::update(float target, float glide) {
   _target = target;
   bool needsUpdate = _frequency != _target;
@@ -29,6 +31,7 @@ void Frequency::update(float target, float glide) {
                        : max(_target, _frequency - _glideStep);
     }
     _ticks = (uint16_t)((31250.0f / _frequency) + 0.5f);
+    _period = (uint16_t)((500000.0f / _frequency) + 0.5f); //uSec
   }
 
   if (!needsUpdate) {
@@ -36,11 +39,11 @@ void Frequency::update(float target, float glide) {
   }
 }
 
-void Frequency::reset() { _frequency = 0; _ticks = 0; }
+void Frequency::reset() { _frequency = 0; _ticks = 0; _period = 0; }
 
 void Frequency::print() {
   Serial.println("frequency:" + String(_frequency) +
-                 ",ticks:" + String(_ticks) +
+                 ",period:" + String(_period) +
                  ",target:" + String(_target) +
                  ",previousTargetFrequency:" + String(_previousTarget));
 }

--- a/arduino/scout/Frequency.h
+++ b/arduino/scout/Frequency.h
@@ -9,11 +9,13 @@ public:
   Frequency(float glide, int cyclesPerGlideMax);
   void update(float target, float glide);
   float get();
+  uint8_t getTicks();
   void reset();
   void print();
 
 private:
   float _frequency = 0;
+  float _ticks = 0;
   float _glide;
   float _glideStep;
   float _previousTarget;

--- a/arduino/scout/Frequency.h
+++ b/arduino/scout/Frequency.h
@@ -10,12 +10,14 @@ public:
   void update(float target, float glide);
   float get();
   uint16_t getTicks();
+  uint16_t getPeriod();
   void reset();
   void print();
 
 private:
   float _frequency = 0;
   uint16_t _ticks = 0;
+  uint16_t _period = 0;
   float _glide;
   float _glideStep;
   float _previousTarget;

--- a/arduino/scout/Frequency.h
+++ b/arduino/scout/Frequency.h
@@ -9,13 +9,13 @@ public:
   Frequency(float glide, int cyclesPerGlideMax);
   void update(float target, float glide);
   float get();
-  uint8_t getTicks();
+  uint16_t getTicks();
   void reset();
   void print();
 
 private:
   float _frequency = 0;
-  float _ticks = 0;
+  uint16_t _ticks = 0;
   float _glide;
   float _glideStep;
   float _previousTarget;

--- a/arduino/scout/KeyBuffer.cpp
+++ b/arduino/scout/KeyBuffer.cpp
@@ -106,3 +106,7 @@ void KeyBuffer::print() {
 }
 
 char KeyBuffer::getFirst() { return _buffer.first(); }
+
+uint8_t KeyBuffer::getSize() { return _buffer.size(); }
+
+char KeyBuffer::getElement(uint8_t e) { return _buffer[e]; }

--- a/arduino/scout/KeyBuffer.cpp
+++ b/arduino/scout/KeyBuffer.cpp
@@ -69,7 +69,7 @@ void KeyBuffer::populate() {
 
   _buttons.getKeys(); // populate keys
 
-  for (int i = LIST_MAX-1; i >= 0; i--) {
+  for (int i = 0; i < LIST_MAX; i++) {
     byte kstate = _buttons.key[i].kstate;
     byte kchar = _buttons.key[i].kchar - 1;
 

--- a/arduino/scout/KeyBuffer.cpp
+++ b/arduino/scout/KeyBuffer.cpp
@@ -69,7 +69,7 @@ void KeyBuffer::populate() {
 
   _buttons.getKeys(); // populate keys
 
-  for (int i = 0; i < LIST_MAX; i++) {
+  for (int i = LIST_MAX-1; i >= 0; i--) {
     byte kstate = _buttons.key[i].kstate;
     byte kchar = _buttons.key[i].kchar - 1;
 

--- a/arduino/scout/KeyBuffer.h
+++ b/arduino/scout/KeyBuffer.h
@@ -17,6 +17,8 @@ public:
   void print();
   void printBuffer();
   void populate();
+  uint8_t getSize();
+  char getElement(uint8_t e);
 
 private:
   CircularBuffer<int, BUFFER_MAX> _buffer;

--- a/arduino/scout/NewTone.cpp
+++ b/arduino/scout/NewTone.cpp
@@ -4,6 +4,7 @@
 
 uint8_t speaker_preload[BUFFER_MAX] = {0};
 
+// Note: rolling this into a loop causes us to miss the timing.
 ISR(TIMER2_OVF_vect) // currently 16 MHz / 256 = 62.5 kHz
 {
   static uint8_t speaker_a_ctr = 1;

--- a/arduino/scout/NewTone.cpp
+++ b/arduino/scout/NewTone.cpp
@@ -2,15 +2,15 @@
 #include "KeyBuffer.h"
 #include "Arduino.h"
 
-uint8_t speaker_preload[BUFFER_MAX] = {0};
+uint16_t speaker_preload[BUFFER_MAX] = {0};
 
 // Note: rolling this into a loop causes us to miss the timing.
 ISR(TIMER2_OVF_vect) // currently 16 MHz / 256 = 62.5 kHz
 {
-  static uint8_t speaker_a_ctr = 1;
-  static uint8_t speaker_b_ctr = 1;
-  static uint8_t speaker_c_ctr = 1;
-  static uint8_t speaker_d_ctr = 1;
+  static uint16_t speaker_a_ctr = 1;
+  static uint16_t speaker_b_ctr = 1;
+  static uint16_t speaker_c_ctr = 1;
+  static uint16_t speaker_d_ctr = 1;
 
   if (speaker_preload[0] != 0) {
     if (--speaker_a_ctr == 0) {

--- a/arduino/scout/NewTone.cpp
+++ b/arduino/scout/NewTone.cpp
@@ -56,5 +56,7 @@ void newToneSetup() {
 }
 
 void loadTone(uint8_t oscillator, uint16_t period) {
-  speaker_preload[oscillator] = period;
+  if (oscillator < BUFFER_MAX) {
+    speaker_preload[oscillator] = period;
+  }
 }

--- a/arduino/scout/NewTone.cpp
+++ b/arduino/scout/NewTone.cpp
@@ -5,7 +5,7 @@
 uint16_t speaker_preload[BUFFER_MAX] = {0};
 
 // Note: rolling this into a loop causes us to miss the timing.
-ISR(TIMER2_OVF_vect) // currently 16 MHz / 256 = 62.5 kHz
+ISR(TIMER2_OVF_vect) // 16 MHz / 256 = 62.5 kHz
 {
   static int16_t speaker_a_ctr = INT_US;
   static int16_t speaker_b_ctr = INT_US;
@@ -49,7 +49,7 @@ void newToneSetup() {
   noInterrupts();
   TCCR2A = 0;
   TCCR2B = 0;
-  TCCR2B |= (0 << CS22) | (0 << CS21) | (1 << CS20); // no prescaler
+  TCCR2B |= (0 << CS22) | (0 << CS21) | (1 << CS20); // no prescaler -- interrupt every 256 ticks at 16 MHz = 62.5 kHz
   TIMSK2 |= (1 << TOIE2); // enable timer overflow interrupt
   interrupts();
 

--- a/arduino/scout/NewTone.cpp
+++ b/arduino/scout/NewTone.cpp
@@ -7,36 +7,40 @@ uint16_t speaker_preload[BUFFER_MAX] = {0};
 // Note: rolling this into a loop causes us to miss the timing.
 ISR(TIMER2_OVF_vect) // currently 16 MHz / 256 = 62.5 kHz
 {
-  static uint16_t speaker_a_ctr = 1;
-  static uint16_t speaker_b_ctr = 1;
-  static uint16_t speaker_c_ctr = 1;
-  static uint16_t speaker_d_ctr = 1;
+  static int16_t speaker_a_ctr = INT_US;
+  static int16_t speaker_b_ctr = INT_US;
+  static int16_t speaker_c_ctr = INT_US;
+  static int16_t speaker_d_ctr = INT_US;
 
   if (speaker_preload[0] != 0) {
-    if (--speaker_a_ctr == 0) {
+    speaker_a_ctr -= INT_US;
+    while (speaker_a_ctr <= 0) {
       PINB |= SPEAKER_A_MASK;
-      speaker_a_ctr = speaker_preload[0];
+      speaker_a_ctr += speaker_preload[0];
     }
   }
 
   if (speaker_preload[1] != 0) {
-    if (--speaker_b_ctr == 0) {
+    speaker_b_ctr -= INT_US;
+    while (speaker_b_ctr <= 0) {
       PINB |= SPEAKER_B_MASK;
-      speaker_b_ctr = speaker_preload[1];
+      speaker_b_ctr += speaker_preload[1];
     }
   }
 
   if (speaker_preload[2] != 0) {
-    if (--speaker_c_ctr == 0) {
+    speaker_c_ctr -= INT_US;
+    while (speaker_c_ctr <= 0) {
       PINB |= SPEAKER_C_MASK;
-      speaker_c_ctr = speaker_preload[2];
+      speaker_c_ctr += speaker_preload[2];
     }
   }
 
   if (speaker_preload[3] != 0) {
-    if (--speaker_d_ctr == 0) {
+    speaker_d_ctr -= INT_US;
+    while (speaker_d_ctr <= 0) {
       PINB |= SPEAKER_D_MASK;
-      speaker_d_ctr = speaker_preload[3];
+      speaker_d_ctr += speaker_preload[3];
     }
   }
 }

--- a/arduino/scout/NewTone.cpp
+++ b/arduino/scout/NewTone.cpp
@@ -7,40 +7,37 @@ uint16_t speaker_preload[BUFFER_MAX] = {0};
 // Note: rolling this into a loop causes us to miss the timing.
 ISR(TIMER2_OVF_vect) // 16 MHz / 256 = 62.5 kHz
 {
-  static int16_t speaker_a_ctr = INT_US;
-  static int16_t speaker_b_ctr = INT_US;
-  static int16_t speaker_c_ctr = INT_US;
-  static int16_t speaker_d_ctr = INT_US;
+  static int16_t speaker_ctr[BUFFER_MAX] = {0};
 
   if (speaker_preload[0] != 0) {
-    speaker_a_ctr -= INT_US;
-    while (speaker_a_ctr <= 0) {
-      PINB |= SPEAKER_A_MASK;
-      speaker_a_ctr += speaker_preload[0];
+    speaker_ctr[0] -= INT_US;
+    while (speaker_ctr[0] <= 0) {
+      PINB |= SPEAKER_MASK[0];
+      speaker_ctr[0] += speaker_preload[0];
     }
   }
 
   if (speaker_preload[1] != 0) {
-    speaker_b_ctr -= INT_US;
-    while (speaker_b_ctr <= 0) {
-      PINB |= SPEAKER_B_MASK;
-      speaker_b_ctr += speaker_preload[1];
+    speaker_ctr[1] -= INT_US;
+    while (speaker_ctr[1] <= 0) {
+      PINB |= SPEAKER_MASK[1];
+      speaker_ctr[1] += speaker_preload[1];
     }
   }
 
   if (speaker_preload[2] != 0) {
-    speaker_c_ctr -= INT_US;
-    while (speaker_c_ctr <= 0) {
-      PINB |= SPEAKER_C_MASK;
-      speaker_c_ctr += speaker_preload[2];
+    speaker_ctr[2] -= INT_US;
+    while (speaker_ctr[2] <= 0) {
+      PINB |= SPEAKER_MASK[2];
+      speaker_ctr[2] += speaker_preload[2];
     }
   }
 
   if (speaker_preload[3] != 0) {
-    speaker_d_ctr -= INT_US;
-    while (speaker_d_ctr <= 0) {
-      PINB |= SPEAKER_D_MASK;
-      speaker_d_ctr += speaker_preload[3];
+    speaker_ctr[3] -= INT_US;
+    while (speaker_ctr[3] <= 0) {
+      PINB |= SPEAKER_MASK[3];
+      speaker_ctr[3] += speaker_preload[3];
     }
   }
 }

--- a/arduino/scout/NewTone.cpp
+++ b/arduino/scout/NewTone.cpp
@@ -1,0 +1,54 @@
+#include "NewTone.h"
+#include "KeyBuffer.h"
+#include "Arduino.h"
+
+uint8_t speaker_preload[BUFFER_MAX] = {0};
+
+ISR(TIMER2_OVF_vect) // currently 16 MHz / 256 = 62.5 kHz
+{
+  static uint8_t speaker_a_ctr = 1;
+  static uint8_t speaker_b_ctr = 1;
+  static uint8_t speaker_c_ctr = 1;
+  static uint8_t speaker_d_ctr = 1;
+
+  if (speaker_preload[0] != 0) {
+    if (--speaker_a_ctr == 0) {
+      PINB |= SPEAKER_A_MASK;
+      speaker_a_ctr = speaker_preload[0];
+    }
+  }
+
+  if (speaker_preload[1] != 0) {
+    if (--speaker_b_ctr == 0) {
+      PINB |= SPEAKER_B_MASK;
+      speaker_b_ctr = speaker_preload[1];
+    }
+  }
+
+  if (speaker_preload[2] != 0) {
+    if (--speaker_c_ctr == 0) {
+      PINB |= SPEAKER_C_MASK;
+      speaker_c_ctr = speaker_preload[2];
+    }
+  }
+
+  if (speaker_preload[3] != 0) {
+    if (--speaker_d_ctr == 0) {
+      PINB |= SPEAKER_D_MASK;
+      speaker_d_ctr = speaker_preload[3];
+    }
+  }
+}
+
+void newToneSetup() {
+  noInterrupts();
+  TCCR2A = 0;
+  TCCR2B = 0;
+  TCCR2B |= (0 << CS22) | (0 << CS21) | (1 << CS20); // no prescaler
+  TIMSK2 |= (1 << TOIE2); // enable timer overflow interrupt
+  interrupts();
+
+  for (uint8_t i = 0; i < BUFFER_MAX; i++) {
+    pinMode(SPEAKER_PINS[i], OUTPUT);
+  }
+}

--- a/arduino/scout/NewTone.cpp
+++ b/arduino/scout/NewTone.cpp
@@ -54,3 +54,7 @@ void newToneSetup() {
     pinMode(SPEAKER_PINS[i], OUTPUT);
   }
 }
+
+void loadTone(uint8_t oscillator, uint16_t period) {
+  speaker_preload[oscillator] = period;
+}

--- a/arduino/scout/NewTone.h
+++ b/arduino/scout/NewTone.h
@@ -12,5 +12,6 @@ const uint8_t INT_US = 16; // uSec = 256 counts in an 8-bit counter / 16 MHz
 extern uint16_t speaker_preload[BUFFER_MAX];
 
 void newToneSetup();
+void loadTone(uint8_t oscillator, uint16_t period);
 
 #endif

--- a/arduino/scout/NewTone.h
+++ b/arduino/scout/NewTone.h
@@ -11,7 +11,7 @@ const uint8_t SPEAKER_B_MASK = 0x04;
 const uint8_t SPEAKER_C_MASK = 0x08;
 const uint8_t SPEAKER_D_MASK = 0x10;
 
-const uint8_t INT_US = 16;
+const uint8_t INT_US = 16; // uSec = 256 counts in an 8-bit counter / 16 MHz
 
 extern uint16_t speaker_preload[BUFFER_MAX];
 

--- a/arduino/scout/NewTone.h
+++ b/arduino/scout/NewTone.h
@@ -11,7 +11,7 @@ const uint8_t SPEAKER_B_MASK = 0x04;
 const uint8_t SPEAKER_C_MASK = 0x08;
 const uint8_t SPEAKER_D_MASK = 0x10;
 
-extern uint8_t speaker_preload[BUFFER_MAX];
+extern uint16_t speaker_preload[BUFFER_MAX];
 
 void newToneSetup();
 

--- a/arduino/scout/NewTone.h
+++ b/arduino/scout/NewTone.h
@@ -1,0 +1,18 @@
+#ifndef NewTone_h
+#define NewTone_h
+
+#include "KeyBuffer.h"
+#include "Arduino.h"
+
+const int SPEAKER_PINS[BUFFER_MAX] = {9, 10, 11, 12};
+
+const uint8_t SPEAKER_A_MASK = 0x02;
+const uint8_t SPEAKER_B_MASK = 0x04;
+const uint8_t SPEAKER_C_MASK = 0x08;
+const uint8_t SPEAKER_D_MASK = 0x10;
+
+extern uint8_t speaker_preload[BUFFER_MAX];
+
+void newToneSetup();
+
+#endif

--- a/arduino/scout/NewTone.h
+++ b/arduino/scout/NewTone.h
@@ -5,11 +5,7 @@
 #include "Arduino.h"
 
 const int SPEAKER_PINS[BUFFER_MAX] = {9, 10, 11, 12};
-
-const uint8_t SPEAKER_A_MASK = 0x02;
-const uint8_t SPEAKER_B_MASK = 0x04;
-const uint8_t SPEAKER_C_MASK = 0x08;
-const uint8_t SPEAKER_D_MASK = 0x10;
+const uint8_t SPEAKER_MASK[BUFFER_MAX] = {0x02, 0x04, 0x08, 0x10};
 
 const uint8_t INT_US = 16; // uSec = 256 counts in an 8-bit counter / 16 MHz
 

--- a/arduino/scout/NewTone.h
+++ b/arduino/scout/NewTone.h
@@ -11,6 +11,8 @@ const uint8_t SPEAKER_B_MASK = 0x04;
 const uint8_t SPEAKER_C_MASK = 0x08;
 const uint8_t SPEAKER_D_MASK = 0x10;
 
+const uint8_t INT_US = 16;
+
 extern uint16_t speaker_preload[BUFFER_MAX];
 
 void newToneSetup();

--- a/arduino/scout/scout.ino
+++ b/arduino/scout/scout.ino
@@ -11,8 +11,68 @@ bool printToSerial = false;
 const int CYCLES_PER_GLIDE_MAX = printToSerial ? 25 : 250;
 const int STARTING_NOTE_DISTANCE_FROM_MIDDLE_A = -9;
 
-// TODO: use other output pins 10,11,12
-const int SPEAKER_PIN = 10;
+// TODO: move all of this into another file
+const int SPEAKER_A = 9;
+const int SPEAKER_B = 10;
+const int SPEAKER_C = 11;
+const int SPEAKER_D = 12;
+
+const uint8_t SPEAKER_A_MASK = 0x02;
+const uint8_t SPEAKER_B_MASK = 0x04;
+const uint8_t SPEAKER_C_MASK = 0x08;
+const uint8_t SPEAKER_D_MASK = 0x10;
+
+// TODO: Move all of this below into another file to abstract away the replacement for tone()
+
+uint8_t speaker_a_preload = 0;
+uint8_t speaker_b_preload = 0;
+uint8_t speaker_c_preload = 0;
+uint8_t speaker_d_preload = 0;
+
+ISR(TIMER2_OVF_vect) // currently 16 MHz / 256 = 62.5 kHz
+{
+  static uint8_t speaker_a_ctr = 1;
+  static uint8_t speaker_b_ctr = 1;
+  static uint8_t speaker_c_ctr = 1;
+  static uint8_t speaker_d_ctr = 1;
+
+  if (speaker_a_preload != 0) {
+    if (--speaker_a_ctr == 0) {
+      PINB |= SPEAKER_A_MASK;
+      speaker_a_ctr = speaker_a_preload;
+    }
+  }
+
+  if (speaker_b_preload != 0) {
+    if (--speaker_b_ctr == 0) {
+      PINB |= SPEAKER_B_MASK;
+      speaker_b_ctr = speaker_b_preload;
+    }
+  }
+
+  if (speaker_c_preload != 0) {
+    if (--speaker_c_ctr == 0) {
+      PINB |= SPEAKER_C_MASK;
+      speaker_c_ctr = speaker_c_preload;
+    }
+  }
+
+  if (speaker_d_preload != 0) {
+    if (--speaker_d_ctr == 0) {
+      PINB |= SPEAKER_D_MASK;
+      speaker_d_ctr = speaker_d_preload;
+    }
+  }
+
+  // TCNT2 = {potentially preload instead of nasty hack};
+}
+
+//TODO: Dynamically calculate these, potentially dithering to get to correct frequency. Need to think about this.
+//      The precision is such that this gets noticably out of tune across two octaves.
+//      Because I am using a table right now, glides are also broken.
+uint8_t freqTable[25] = {239, 225, 213, 201, 190, 179, 169, 159, 150, 142, 134, 127, 119, 113, 106, 100, 95, 89, 84, 80, 75, 71, 67, 63, 60}; // counts for C3-C5 at a base of 61.5 kHz
+
+// END TODO BLOCK
 
 const int OCTAVE_PIN = A4;
 const int GLIDE_PIN = A5;
@@ -49,6 +109,18 @@ void setup() {
   pinMode(PLAYING_INDICATOR_LED, OUTPUT);
   pinMode(FUNCTION_INDICATOR_LED, OUTPUT);
 
+  noInterrupts();
+  TCCR2A = 0;
+  TCCR2B = 0;
+ // TCNT2 = {something}; // potentially could preload the timer
+  TCCR2B |= (0 << CS22) | (0 << CS21) | (1 << CS20); // no prescaler
+  TIMSK2 |= (1 << TOIE2); // enable timer overflow interrupt
+  interrupts();   
+  pinMode(SPEAKER_A, OUTPUT);
+  pinMode(SPEAKER_B, OUTPUT);
+  pinMode(SPEAKER_C, OUTPUT);
+  pinMode(SPEAKER_D, OUTPUT);
+
   blink();
 }
 
@@ -81,12 +153,15 @@ void loop() {
       frequency.reset();
     }
 
-    noTone(SPEAKER_PIN);
+    //noTone(SPEAKER_PIN);
+    speaker_a_preload = 0;
     digitalWrite(PLAYING_INDICATOR_LED, LOW);
   } else {
-    frequency.update(notes.get(buffer.getFirst()) / 4 * pow(2, octave), glide);
+    //frequency.update(notes.get(buffer.getFirst()) / 4 * pow(2, octave), glide);
 
-    tone(SPEAKER_PIN, frequency.get());
+    //tone(SPEAKER_PIN, frequency.get());
+    speaker_a_preload = freqTable[buffer.getFirst()];
     digitalWrite(PLAYING_INDICATOR_LED, HIGH);
   }
 }
+

--- a/arduino/scout/scout.ino
+++ b/arduino/scout/scout.ino
@@ -53,7 +53,7 @@ void setup() {
 }
 
 void updateFromAnalogInputs() {
-  int newOctave = map(analogRead(OCTAVE_PIN), 0, 1023, 1, 3);
+  int newOctave = map(analogRead(OCTAVE_PIN), 0, 1023, -1, 3);
   float newGlide = float(analogRead(GLIDE_PIN)) / 1023;
 
   if (octave != newOctave || glide != newGlide) {

--- a/arduino/scout/scout.ino
+++ b/arduino/scout/scout.ino
@@ -1,6 +1,7 @@
 #include "Frequency.h"
 #include "KeyBuffer.h"
 #include "Notes.h"
+#include "NewTone.h"
 
 // SETTINGS
 int octave = 3;
@@ -20,59 +21,6 @@ const int FUNCTION_INDICATOR_LED = A3;
 Notes notes(STARTING_NOTE_DISTANCE_FROM_MIDDLE_A);
 KeyBuffer buffer;
 Frequency frequency[BUFFER_MAX] = { {glide, CYCLES_PER_GLIDE_MAX}, {glide, CYCLES_PER_GLIDE_MAX}, {glide, CYCLES_PER_GLIDE_MAX}, {glide, CYCLES_PER_GLIDE_MAX} };
-
-// TODO: move all of this into another file
-const int SPEAKER_A = 9;
-const int SPEAKER_B = 10;
-const int SPEAKER_C = 11;
-const int SPEAKER_D = 12;
-
-const uint8_t SPEAKER_A_MASK = 0x02;
-const uint8_t SPEAKER_B_MASK = 0x04;
-const uint8_t SPEAKER_C_MASK = 0x08;
-const uint8_t SPEAKER_D_MASK = 0x10;
-
-// TODO: Move all of this below into another file to abstract away the replacement for tone()
-
-uint8_t speaker_preload[BUFFER_MAX] = {0};
-
-ISR(TIMER2_OVF_vect) // currently 16 MHz / 256 = 62.5 kHz
-{
-  static uint8_t speaker_a_ctr = 1;
-  static uint8_t speaker_b_ctr = 1;
-  static uint8_t speaker_c_ctr = 1;
-  static uint8_t speaker_d_ctr = 1;
-
-  if (speaker_preload[0] != 0) {
-    if (--speaker_a_ctr == 0) {
-      PINB |= SPEAKER_A_MASK;
-      speaker_a_ctr = speaker_preload[0];
-    }
-  }
-
-  if (speaker_preload[1] != 0) {
-    if (--speaker_b_ctr == 0) {
-      PINB |= SPEAKER_B_MASK;
-      speaker_b_ctr = speaker_preload[1];
-    }
-  }
-
-  if (speaker_preload[2] != 0) {
-    if (--speaker_c_ctr == 0) {
-      PINB |= SPEAKER_C_MASK;
-      speaker_c_ctr = speaker_preload[2];
-    }
-  }
-
-  if (speaker_preload[3] != 0) {
-    if (--speaker_d_ctr == 0) {
-      PINB |= SPEAKER_D_MASK;
-      speaker_d_ctr = speaker_preload[3];
-    }
-  }
-}
-
-// END TODO BLOCK
 
 void blink(int count = 2, int timePerColor = 100) {
   while (count >= 0) {
@@ -99,16 +47,7 @@ void setup() {
   pinMode(PLAYING_INDICATOR_LED, OUTPUT);
   pinMode(FUNCTION_INDICATOR_LED, OUTPUT);
 
-  noInterrupts();
-  TCCR2A = 0;
-  TCCR2B = 0;
-  TCCR2B |= (0 << CS22) | (0 << CS21) | (1 << CS20); // no prescaler
-  TIMSK2 |= (1 << TOIE2); // enable timer overflow interrupt
-  interrupts();   
-  pinMode(SPEAKER_A, OUTPUT);
-  pinMode(SPEAKER_B, OUTPUT);
-  pinMode(SPEAKER_C, OUTPUT);
-  pinMode(SPEAKER_D, OUTPUT);
+  newToneSetup();
 
   blink();
 }

--- a/arduino/scout/scout.ino
+++ b/arduino/scout/scout.ino
@@ -53,7 +53,7 @@ void setup() {
 }
 
 void updateFromAnalogInputs() {
-  int newOctave = map(analogRead(OCTAVE_PIN), 0, 1023, -1, 3);
+  int newOctave = map(analogRead(OCTAVE_PIN), 0, 1023, -1, 4);
   float newGlide = float(analogRead(GLIDE_PIN)) / 1023;
 
   if (octave != newOctave || glide != newGlide) {
@@ -90,7 +90,7 @@ void loop() {
 
   for (i = 0; i < size; i++) {
     frequency[i].update(notes.get(buffer.getElement(i)) / 4 * pow(2, octave), glide);
-    speaker_preload[i] = frequency[i].getTicks();
+    speaker_preload[i] = frequency[i].getPeriod();
   }
   for (; i < BUFFER_MAX; i++) {
     if (!glideOnFreshKeyPresses) {

--- a/arduino/scout/scout.ino
+++ b/arduino/scout/scout.ino
@@ -90,13 +90,13 @@ void loop() {
 
   for (i = 0; i < size; i++) {
     frequency[i].update(notes.get(buffer.getElement(i)) / 4 * pow(2, octave), glide);
-    speaker_preload[i] = frequency[i].getPeriod();
+    loadTone(i, frequency[i].getPeriod());
   }
   for (; i < BUFFER_MAX; i++) {
     if (!glideOnFreshKeyPresses) {
       frequency[i].reset();
     }
-    speaker_preload[i] = 0;
+    loadTone(i, 0);
   }
 }
 

--- a/arduino/scout/scout.ino
+++ b/arduino/scout/scout.ino
@@ -53,7 +53,7 @@ void setup() {
 }
 
 void updateFromAnalogInputs() {
-  int newOctave = map(analogRead(OCTAVE_PIN), 0, 1023, 0, 4);
+  int newOctave = map(analogRead(OCTAVE_PIN), 0, 1023, 1, 3);
   float newGlide = float(analogRead(GLIDE_PIN)) / 1023;
 
   if (octave != newOctave || glide != newGlide) {

--- a/arduino/scout/scout.ino
+++ b/arduino/scout/scout.ino
@@ -11,6 +11,16 @@ bool printToSerial = false;
 const int CYCLES_PER_GLIDE_MAX = printToSerial ? 25 : 250;
 const int STARTING_NOTE_DISTANCE_FROM_MIDDLE_A = -9;
 
+const int OCTAVE_PIN = A4;
+const int GLIDE_PIN = A5;
+
+const int PLAYING_INDICATOR_LED = 13; // ie LED_BUILTIN
+const int FUNCTION_INDICATOR_LED = A3;
+
+Notes notes(STARTING_NOTE_DISTANCE_FROM_MIDDLE_A);
+KeyBuffer buffer;
+Frequency frequency[BUFFER_MAX] = { {glide, CYCLES_PER_GLIDE_MAX}, {glide, CYCLES_PER_GLIDE_MAX}, {glide, CYCLES_PER_GLIDE_MAX}, {glide, CYCLES_PER_GLIDE_MAX} };
+
 // TODO: move all of this into another file
 const int SPEAKER_A = 9;
 const int SPEAKER_B = 10;
@@ -24,10 +34,7 @@ const uint8_t SPEAKER_D_MASK = 0x10;
 
 // TODO: Move all of this below into another file to abstract away the replacement for tone()
 
-uint8_t speaker_a_preload = 0;
-uint8_t speaker_b_preload = 0;
-uint8_t speaker_c_preload = 0;
-uint8_t speaker_d_preload = 0;
+uint8_t speaker_preload[BUFFER_MAX] = {0};
 
 ISR(TIMER2_OVF_vect) // currently 16 MHz / 256 = 62.5 kHz
 {
@@ -36,35 +43,33 @@ ISR(TIMER2_OVF_vect) // currently 16 MHz / 256 = 62.5 kHz
   static uint8_t speaker_c_ctr = 1;
   static uint8_t speaker_d_ctr = 1;
 
-  if (speaker_a_preload != 0) {
+  if (speaker_preload[0] != 0) {
     if (--speaker_a_ctr == 0) {
       PINB |= SPEAKER_A_MASK;
-      speaker_a_ctr = speaker_a_preload;
+      speaker_a_ctr = speaker_preload[0];
     }
   }
 
-  if (speaker_b_preload != 0) {
+  if (speaker_preload[1] != 0) {
     if (--speaker_b_ctr == 0) {
       PINB |= SPEAKER_B_MASK;
-      speaker_b_ctr = speaker_b_preload;
+      speaker_b_ctr = speaker_preload[1];
     }
   }
 
-  if (speaker_c_preload != 0) {
+  if (speaker_preload[2] != 0) {
     if (--speaker_c_ctr == 0) {
       PINB |= SPEAKER_C_MASK;
-      speaker_c_ctr = speaker_c_preload;
+      speaker_c_ctr = speaker_preload[2];
     }
   }
 
-  if (speaker_d_preload != 0) {
+  if (speaker_preload[3] != 0) {
     if (--speaker_d_ctr == 0) {
       PINB |= SPEAKER_D_MASK;
-      speaker_d_ctr = speaker_d_preload;
+      speaker_d_ctr = speaker_preload[3];
     }
   }
-
-  // TCNT2 = {potentially preload instead of nasty hack};
 }
 
 //TODO: Dynamically calculate these, potentially dithering to get to correct frequency. Need to think about this.
@@ -73,16 +78,6 @@ ISR(TIMER2_OVF_vect) // currently 16 MHz / 256 = 62.5 kHz
 uint8_t freqTable[25] = {239, 225, 213, 201, 190, 179, 169, 159, 150, 142, 134, 127, 119, 113, 106, 100, 95, 89, 84, 80, 75, 71, 67, 63, 60}; // counts for C3-C5 at a base of 61.5 kHz
 
 // END TODO BLOCK
-
-const int OCTAVE_PIN = A4;
-const int GLIDE_PIN = A5;
-
-const int PLAYING_INDICATOR_LED = 13; // ie LED_BUILTIN
-const int FUNCTION_INDICATOR_LED = A3;
-
-Notes notes(STARTING_NOTE_DISTANCE_FROM_MIDDLE_A);
-KeyBuffer buffer;
-Frequency frequency(glide, CYCLES_PER_GLIDE_MAX);
 
 void blink(int count = 2, int timePerColor = 100) {
   while (count >= 0) {
@@ -112,7 +107,6 @@ void setup() {
   noInterrupts();
   TCCR2A = 0;
   TCCR2B = 0;
- // TCNT2 = {something}; // potentially could preload the timer
   TCCR2B |= (0 << CS22) | (0 << CS21) | (1 << CS20); // no prescaler
   TIMSK2 |= (1 << TOIE2); // enable timer overflow interrupt
   interrupts();   
@@ -139,34 +133,37 @@ void updateFromAnalogInputs() {
 }
 
 void loop() {
+  uint8_t i;
+  
   buffer.populate();
 
   // TODO: do this less often...
   updateFromAnalogInputs();
 
   if (printToSerial) {
-    frequency.print();
+    frequency[0].print();
   }
 
   if (buffer.isEmpty()) {
-    if (!glideOnFreshKeyPresses) {
-      frequency.reset();
-    }
-
-    //noTone(SPEAKER_PIN);
     digitalWrite(PLAYING_INDICATOR_LED, LOW);
   } else {
-    //frequency.update(notes.get(buffer.getFirst()) / 4 * pow(2, octave), glide);
-
-    //tone(SPEAKER_PIN, frequency.get());
-   
     digitalWrite(PLAYING_INDICATOR_LED, HIGH);
   }
 
   uint8_t size = buffer.getSize();
-  speaker_a_preload = (size > 0) ? freqTable[buffer.getElement(0)] : 0;
-  speaker_b_preload = (size > 1) ? freqTable[buffer.getElement(1)] : 0;
-  speaker_c_preload = (size > 2) ? freqTable[buffer.getElement(2)] : 0;
-  speaker_d_preload = (size > 3) ? freqTable[buffer.getElement(3)] : 0;
+
+  for (i = 0; i < buffer.getSize(); i++) {
+    frequency[i].update(notes.get(buffer.getElement(i)) / 4 * pow(2, octave), glide);
+  }
+  for (; i < BUFFER_MAX; i++) {
+    if (!glideOnFreshKeyPresses) {
+      frequency[i].reset();
+    }
+  }
+
+  speaker_preload[0] = (size > 0) ? frequency[0].getTicks() : 0;
+  speaker_preload[1] = (size > 1) ? frequency[1].getTicks() : 0;
+  speaker_preload[2] = (size > 2) ? frequency[2].getTicks() : 0;
+  speaker_preload[3] = (size > 3) ? frequency[3].getTicks() : 0;
 }
 

--- a/arduino/scout/scout.ino
+++ b/arduino/scout/scout.ino
@@ -154,14 +154,19 @@ void loop() {
     }
 
     //noTone(SPEAKER_PIN);
-    speaker_a_preload = 0;
     digitalWrite(PLAYING_INDICATOR_LED, LOW);
   } else {
     //frequency.update(notes.get(buffer.getFirst()) / 4 * pow(2, octave), glide);
 
     //tone(SPEAKER_PIN, frequency.get());
-    speaker_a_preload = freqTable[buffer.getFirst()];
+   
     digitalWrite(PLAYING_INDICATOR_LED, HIGH);
   }
+
+  uint8_t size = buffer.getSize();
+  speaker_a_preload = (size > 0) ? freqTable[buffer.getElement(0)] : 0;
+  speaker_b_preload = (size > 1) ? freqTable[buffer.getElement(1)] : 0;
+  speaker_c_preload = (size > 2) ? freqTable[buffer.getElement(2)] : 0;
+  speaker_d_preload = (size > 3) ? freqTable[buffer.getElement(3)] : 0;
 }
 


### PR DESCRIPTION
Adds four-note polyphony with glides. Replaces the call to tone() with an ISR which fires every 16 us.

The ISR uses a number of microseconds equal to half of the period (precomputed by the Frequency class) to toggle up to four speaker pins at the right time to produce tones.

The minimum of 16 us per interrupt reduces the accuracy of the produced tone as the pitch gets higher. Due to this limitation, I use something like dithering in order to approximate average higher pitch accuracy instead of the quantization making things sound really out of tune. This sounds something like vibrato.