### PR TITLE
adding MIDI controller example

### DIFF
--- a/arduino/Scout_2_MIDI_Out/KeyBuffer.cpp
+++ b/arduino/Scout_2_MIDI_Out/KeyBuffer.cpp
@@ -1,0 +1,112 @@
+#include "KeyBuffer.h"
+#include "Arduino.h"
+
+#define CIRCULAR_BUFFER_DEBUG
+#include <CircularBuffer.hpp>
+#include <Keypad.h>
+
+const byte ROWS = 5;
+const byte COLS = 5;
+byte key_indexes[ROWS][COLS] = {{1, 6, 11, 16, 21},
+                                {2, 7, 12, 17, 22},
+                                {3, 8, 13, 18, 23},
+                                {4, 9, 14, 19, 24},
+                                {5, 10, 15, 20, 25}};
+byte rowPins[ROWS] = {7, 8, 14, 15, 16};
+byte colPins[COLS] = {2, 3, 4, 5, 6};
+
+Keypad _buttons = Keypad(makeKeymap(key_indexes), rowPins, colPins, ROWS, COLS);
+
+KeyBuffer::KeyBuffer() {
+  CircularBuffer<int, BUFFER_MAX> _buffer;
+
+  const int KEYPAD_LIBRARY_MINIMUM_DEBOUNCE = 1;
+  _buttons.setDebounceTime(KEYPAD_LIBRARY_MINIMUM_DEBOUNCE);
+}
+
+bool KeyBuffer::isEmpty() { return _buffer.isEmpty(); }
+
+bool KeyBuffer::isInBuffer(int c) {
+  bool value = false;
+
+  if (!_buffer.isEmpty()) {
+    for (int i = 0; i < _buffer.size(); i++) {
+      if (c == _buffer[i]) {
+        value = true;
+        break;
+      }
+    }
+  }
+
+  return value;
+}
+
+bool KeyBuffer::removeFromBuffer(int c) {
+  int newStack[BUFFER_MAX - 1] = {};
+  int newI = 0;
+
+  bool hasRemoval = false;
+
+  for (int i = 0; i < _buffer.size(); i++) {
+    if (c != _buffer[i]) {
+      newStack[newI++] = _buffer[i];
+    } else {
+      hasRemoval = true;
+    }
+  }
+
+  if (hasRemoval) {
+    _buffer.clear();
+
+    for (byte i = 0; i < newI; i++) {
+      _buffer.push(newStack[i]);
+    }
+  }
+}
+
+void KeyBuffer::populate() {
+  bool isActive = false;
+
+  _buttons.getKeys(); // populate keys
+
+  for (int i = 0; i < LIST_MAX; i++) {
+    byte kstate = _buttons.key[i].kstate;
+    byte kchar = _buttons.key[i].kchar - 1;
+
+    if (kstate == PRESSED || kstate == HOLD) {
+      if (!isInBuffer(kchar)) {
+        _buffer.unshift(kchar);
+      }
+
+      isActive = true;
+    } else if (isInBuffer(kchar)) {
+      removeFromBuffer(kchar);
+    }
+  }
+
+  if (!isActive) {
+    _buffer.clear();
+  }
+}
+
+void KeyBuffer::print() {
+  if (!_buffer.isEmpty()) {
+    Serial.print("[");
+    for (int i = 0; i < _buffer.size(); i++) {
+      Serial.print(_buffer[i]);
+
+      if (i < _buffer.size() - 1) {
+        Serial.print(",");
+      }
+    }
+    Serial.print("] (" + String(_buffer.size()) + "/" + String(BUFFER_MAX) +
+                 ")");
+    Serial.println();
+  }
+}
+
+char KeyBuffer::getFirst() { return _buffer.first(); }
+
+uint8_t KeyBuffer::getSize() { return _buffer.size(); }
+
+char KeyBuffer::getElement(uint8_t e) { return _buffer[e]; }

--- a/arduino/Scout_2_MIDI_Out/KeyBuffer.h
+++ b/arduino/Scout_2_MIDI_Out/KeyBuffer.h
@@ -1,0 +1,29 @@
+#define CIRCULAR_BUFFER_DEBUG
+#include <CircularBuffer.hpp>
+#include <Keypad.h>
+
+#ifndef KeyBuffer_h
+#define KeyBuffer_h
+
+#include "Arduino.h"
+
+#define BUFFER_MAX 25  // increased to handle all keys. 6 note chords are necessary.
+
+class KeyBuffer {
+public:
+  KeyBuffer();
+  bool isEmpty();
+  char getFirst();
+  void print();
+  void printBuffer();
+  void populate();
+  uint8_t getSize();
+  char getElement(uint8_t e);
+
+private:
+  CircularBuffer<int, BUFFER_MAX> _buffer;
+  bool isInBuffer(int c);
+  bool removeFromBuffer(int c);
+};
+
+#endif

--- a/arduino/Scout_2_MIDI_Out/MIDI_Notes.cpp
+++ b/arduino/Scout_2_MIDI_Out/MIDI_Notes.cpp
@@ -1,0 +1,36 @@
+#include "MIDI_Notes.h"
+#include "Arduino.h"
+
+MIDI_Notes::MIDI_Notes(int baseNote) {
+  _baseNote = baseNote;
+  _octaveShift = 0;
+  updateNotes();
+}
+
+void MIDI_Notes::updateNotes() {
+  for (int i = 0; i < NOTES_COUNT; i++) {
+    // Calculate MIDI note number for each key
+    // baseNote + key index + octave shift (12 semitones per octave)
+    _notes[i] = _baseNote + i + (_octaveShift * 12);
+    
+    // Clamp to valid MIDI range (0-127)
+    if (_notes[i] < 0) _notes[i] = 0;
+    if (_notes[i] > 127) _notes[i] = 127;
+  }
+}
+
+int MIDI_Notes::get(int keyIndex) {
+  if (keyIndex >= 0 && keyIndex < NOTES_COUNT) {
+    return _notes[keyIndex];
+  }
+  return -1; // Invalid key
+}
+
+void MIDI_Notes::setOctaveShift(int shift) {
+  _octaveShift = shift;
+  updateNotes();
+}
+
+int MIDI_Notes::getOctaveShift() {
+  return _octaveShift;
+}

--- a/arduino/Scout_2_MIDI_Out/MIDI_Notes.h
+++ b/arduino/Scout_2_MIDI_Out/MIDI_Notes.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2025 Liz Clark
+//
+// SPDX-License-Identifier: MIT
+/*
+  MIDI Notes helper. Adjusts assigned MIDI note numbers similar to the Notes helper.
+*/
+#ifndef MIDI_Notes_h
+#define MIDI_Notes_h
+
+#include "Arduino.h"
+
+const int NOTES_COUNT = 25;
+const int MIDI_NOTE_OFF = 0x80;
+const int MIDI_NOTE_ON = 0x90;
+
+class MIDI_Notes {
+public:
+  MIDI_Notes(int baseNote = 48); // Default to C3 (middle C)
+  int get(int keyIndex);
+  void setOctaveShift(int shift);
+  int getOctaveShift();
+  
+private:
+  int _baseNote;
+  int _octaveShift;
+  int _notes[NOTES_COUNT];
+  void updateNotes();
+};
+
+#endif

--- a/arduino/Scout_2_MIDI_Out/Scout_2_MIDI_Out.ino
+++ b/arduino/Scout_2_MIDI_Out/Scout_2_MIDI_Out.ino
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2025 Liz Clark
+//
+// SPDX-License-Identifier: MIT
+/*
+  Scout 2 MIDI Keyboard Controller
+  * NoteOn and NoteOff messages for each key press
+  * OCTAVE_PIN adjusts MIDI note number range
+  * GLIDE_PIN controls pitch bend
+*/
+
+#include "Arduino.h"
+#include "KeyBuffer.h"
+#include "MIDI_Notes.h"
+
+// pin defs
+const int OCTAVE_PIN = A4;
+const int GLIDE_PIN = A5;
+const int PLAYING_INDICATOR_LED = 13;
+const int FUNCTION_INDICATOR_LED = A3;
+
+// MIDI constants
+const int MIDI_CHANNEL = 1;
+const int DEFAULT_VELOCITY = 64; // middle velocity
+
+KeyBuffer buffer;
+MIDI_Notes midiNotes(48); // start at C3 (MIDI note 48)
+
+// variables
+int octave = 0;
+int pitchBend = 8192; // center position (no bend)
+bool activeNotes[25] = {false}; // track which notes are pressed
+unsigned long lastNoteTime[25] = {0}; // debounce timing for each key
+const unsigned long NOTE_DEBOUNCE = 20; //
+
+void blink(int count = 2, int timePerColor = 100) {
+  while (count >= 0) {
+    digitalWrite(PLAYING_INDICATOR_LED, HIGH);
+    digitalWrite(FUNCTION_INDICATOR_LED, LOW);
+    delay(timePerColor);
+    digitalWrite(PLAYING_INDICATOR_LED, HIGH);
+    digitalWrite(FUNCTION_INDICATOR_LED, HIGH);
+    delay(timePerColor);
+    digitalWrite(PLAYING_INDICATOR_LED, LOW);
+    digitalWrite(FUNCTION_INDICATOR_LED, HIGH);
+    delay(timePerColor);
+    digitalWrite(PLAYING_INDICATOR_LED, LOW);
+    digitalWrite(FUNCTION_INDICATOR_LED, LOW);
+    delay(timePerColor);
+    count = count - 1;
+  }
+}
+
+void setup() {
+  // MIDI baud rate:
+  Serial.begin(31250);
+  
+  pinMode(PLAYING_INDICATOR_LED, OUTPUT);
+  pinMode(FUNCTION_INDICATOR_LED, OUTPUT);
+
+  blink();
+  
+  // send initial pitch bend to center position
+  sendPitchBend(MIDI_CHANNEL, 8192);
+}
+
+void sendPitchBend(int channel, int bend) {
+  // pitch bend uses 14-bit value split into LSB and MSB
+  int lsb = bend & 0x7F;
+  int msb = (bend >> 7) & 0x7F;
+  
+  Serial.write(0xE0 | (channel - 1)); // pitch bend message
+  Serial.write(lsb);
+  Serial.write(msb);
+}
+
+void sendAllNotesOff() {
+  // all notes off (CC 123)
+  Serial.write(0xB0 | (MIDI_CHANNEL - 1)); // CC
+  Serial.write(123); // 123
+  Serial.write(0);
+}
+
+void updateFromAnalogInputs() {
+  int newOctave = map(analogRead(OCTAVE_PIN), 0, 1023, -2, 2); // -2 to +2 octaves
+  int newPitchBend = map(analogRead(GLIDE_PIN), 0, 1023, 0, 16383); // pitch bend range
+  
+  if (octave != newOctave) {
+    // send all notes off before changing octave, avoid stuck notes
+    sendAllNotesOff();
+    
+    octave = newOctave;
+    midiNotes.setOctaveShift(octave);
+    digitalWrite(FUNCTION_INDICATOR_LED, HIGH);
+  } else if (abs(pitchBend - newPitchBend) > 64) { // Add some hysteresis to reduce jitter
+    pitchBend = newPitchBend;
+    sendPitchBend(MIDI_CHANNEL, pitchBend);
+    digitalWrite(FUNCTION_INDICATOR_LED, HIGH);
+  } else {
+    digitalWrite(FUNCTION_INDICATOR_LED, LOW);
+  }
+}
+
+void sendNoteOn(int channel, int pitch, int velocity) {
+  Serial.write(MIDI_NOTE_ON | (channel - 1));
+  Serial.write(pitch);
+  Serial.write(velocity);
+}
+
+void sendNoteOff(int channel, int pitch) {
+  Serial.write(MIDI_NOTE_OFF | (channel - 1));
+  Serial.write(pitch);
+  Serial.write(0);
+}
+
+void loop() {
+  // update octave and glide from analog inputs
+  updateFromAnalogInputs();
+  
+  // update the key buffer with current key states
+  buffer.populate();
+  
+  // update playing indicator LED
+  if (buffer.isEmpty()) {
+    digitalWrite(PLAYING_INDICATOR_LED, LOW);
+  } else {
+    digitalWrite(PLAYING_INDICATOR_LED, HIGH);
+  }
+  
+  // scan matrix for noteon/noteoff
+  for (int i = 0; i < 25; i++) {
+    bool isPressed = false;
+    for (int j = 0; j < buffer.getSize(); j++) {
+      if (buffer.getElement(j) == i) {
+        isPressed = true;
+        break;
+      }
+    }
+    // debounce
+    unsigned long currentTime = millis();
+
+    if (isPressed && !activeNotes[i]) {
+      // key was just pressed
+      if (currentTime - lastNoteTime[i] > NOTE_DEBOUNCE) {
+        int midiNote = midiNotes.get(i);
+        if (midiNote >= 0) {
+          sendNoteOn(MIDI_CHANNEL, midiNote, DEFAULT_VELOCITY);
+          activeNotes[i] = true;
+          lastNoteTime[i] = currentTime;
+        }
+      }
+    } else if (!isPressed && activeNotes[i]) {
+      // key was just released
+      if (currentTime - lastNoteTime[i] > NOTE_DEBOUNCE) {
+        int midiNote = midiNotes.get(i);
+        if (midiNote >= 0) {
+          sendNoteOff(MIDI_CHANNEL, midiNote);
+          activeNotes[i] = false;
+          lastNoteTime[i] = currentTime;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Scout 2 MIDI Keyboard Controller
  * NoteOn and NoteOff messages for each key press
  * OCTAVE_PIN adjusts MIDI note number range
  * GLIDE_PIN controls pitch bend

i tried to match the API from the Notes helper in the scout example to the MIDI_Notes helper. tested with a DIN-5 MIDI to USB MIDI cable